### PR TITLE
Add git for plugin install support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM alpine/helm:3.2.4
 # hadolint ignore=DL3002
 USER root
 
+RUN apk --update add git less openssh bash && \
+            rm -rf /var/lib/apt/lists/* && \
+            rm /var/cache/apk/*
+
 RUN mkdir /workdir
 COPY entrypoint.sh /workdir/entrypoint.sh
 RUN chmod +x /workdir/entrypoint.sh


### PR DESCRIPTION
Hi,
I've add git support for helm plugin installation

Example;
helm plugin install https://github.com/hypnoglow/helm-s3.git