### PR TITLE
Сlearing error mkdir: can't create directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo -e "\033[36mSetting up kubectl configuration\033[0m"
-mkdir ~/.kube/ || true
+mkdir -p ~/.kube/
 echo "${INPUT_KUBECONFIG}" > ~/.kube/config
 
 echo -e "\033[36mPreparing helm execution\033[0m"


### PR DESCRIPTION
mkdir -p instead "|| true"
Allows you to remove a non-critical error from the log:
"mkdir: can't create directory '/github/home/.kube/': File exists"