### PR TITLE
Properly handle writing multi-line output

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,10 +1,13 @@
 async function main() {
+    const {randomUUID} = require('crypto');
     const homedir = require('os').homedir();
     const tempdir = require('os').tmpdir();
     const fs = require('fs');
     const {execFile} = require('child_process');
     const tmp = require('tmp');
     const {waitFile} = require('wait-file');
+
+    const multiLineDelimiter = randomUUID();
 
     console.log("\033[36mPWD: " + process.cwd() + "\033[0m");
 
@@ -108,7 +111,10 @@ async function main() {
                 }
             });
         });
-        fs.appendFileSync(process.env.GITHUB_OUTPUT, 'helm_output=' + result.trim().split('%').join('%25').split('\n').join('%0A').split('\r').join('%0D') + '\n');
+        fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `helm_output<<${multiLineDelimiter}\n${result.trim()}\n${multiLineDelimiter}\n`
+        );
     } catch (error) {
         process.exit(1);
     } finally {

--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ async function main() {
             kubeConfigLocation,
             "\r\n\r\n" + process.env.INPUT_KUBECONFIG + "\r\n\r\n",
             {
-                mode: 0o644,
+                mode: 0o600,
             }
         );
     } else if (kubeConfigExists) {
@@ -54,7 +54,7 @@ async function main() {
             kubeConfigLocation,
             "\r\n\r\n" + process.env.INPUT_KUBECONFIG + "\r\n\r\n",
             {
-                mode: 0o644,
+                mode: 0o600,
             }
         );
     }
@@ -63,7 +63,7 @@ async function main() {
         dockerKubeConfig,
         fs.readFileSync(kubeConfigLocation),
         {
-            mode: 0o777,
+            mode: 0o600,
         }
     );
     console.log("\033[36mPreparing helm execution\033[0m");

--- a/main.js
+++ b/main.js
@@ -96,7 +96,7 @@ async function main() {
 
     try {
         console.log("\033[36mExecuting helm\033[0m");
-        result = await new Promise((resolve, reject) => {
+        const result = await new Promise((resolve, reject) => {
             const process = execFile(execShFile.name);
             process.stdout.on('data', console.log);
             process.stderr.on('data', console.log);
@@ -111,10 +111,16 @@ async function main() {
                 }
             });
         });
+        const [output, notes] = result.split(/^NOTES:$/m);
         fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
-            `helm_output<<${multiLineDelimiter}\n${result.trim()}\n${multiLineDelimiter}\n`
+            `helm_output<<${multiLineDelimiter}\n${output}\n${multiLineDelimiter}\n`
         );
+        fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `helm_notes<<${multiLineDelimiter}\n${notes}\n${multiLineDelimiter}\n`
+        );
+        
     } catch (error) {
         process.exit(1);
     } finally {


### PR DESCRIPTION
The Github Actions Docs specifies that you can use the same multi-line output format for outputs as you can for environment variables. You do not need to do any wacky escaping of newlines and such. That just makes the output hard to work with.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings