### PR TITLE
Fix Multiline Output

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,10 +1,13 @@
 async function main() {
+    const {randomUUID} = require('crypto');
     const homedir = require('os').homedir();
     const tempdir = require('os').tmpdir();
     const fs = require('fs');
     const {execFile} = require('child_process');
     const tmp = require('tmp');
     const {waitFile} = require('wait-file');
+
+    const multiLineDelimiter = randomUUID();
 
     console.log("\033[36mPWD: " + process.cwd() + "\033[0m");
 
@@ -108,7 +111,10 @@ async function main() {
                 }
             });
         });
-        fs.appendFileSync(process.env.GITHUB_OUTPUT, 'helm_output=' + result.trim().split('%').join('%25').split('\n').join('%0A').split('\r').join('%0D') + '\n');
+        fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `helm_output<<${multiLineDelimiter}\n${result.trim()}\n${multiLineDelimiter}\n`
+        );
     } catch (error) {
         process.exit(1);
     } finally {


### PR DESCRIPTION
It is undocumented functionality, but this actions workflow does also expose the result of the `helm` command execution as an output called `helm_output`. Unfortunately, because a lot of unnecessary character escaping is done for newlines, carriage returns, and the percent symbol, the result is fairly difficult to use.

The Github Actions Docs specifies that you can use the same multi-line output format for outputs as you can for environment variables, so no special tricks are required. The approach is based on the same standard heredoc method you would use in a shell script.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings

> [!IMPORTANT]
> ~~This pull request does also include a further enhancement which splits helm's `NOTES.txt` output from the rest of the output, and populates separate Github Actions outputs for each. This makes it easier to render the `NOTES.txt` into the Markdown-formatted workflow summary.~~
>
> ~~The two outputs are:~~
> - ~~`helm_output` – Everything that was output by the `helm` command ***before*** the line `NOTES:`~~
> - ~~`helm_notes` – Everything that was output by the `helm` command ***after*** the line `NOTES:`~~
>
> ~~Please let me know if you want a clean pull request that does not make both of these changes at once.~~
> ***Update: this has been extracted into a separate PR. #92 ***